### PR TITLE
Fix card stretching in Sections dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Stretched card in Sections dashboards** (`astroweather-card.ts`, `style.ts`): The card, especially its "entity not available" / "not an AstroWeather entity" error states, could render badly stretched in Home Assistant's Sections dashboard view. `getCardSize()` previously fell back to a fixed size of 4 rows whenever it was queried before the card had rendered, and the `.not-found` box used `flex: 1` inside a non-flex container, both of which caused an oversized layout. Added `getGridOptions()` so Sections view sizes the card to its actual content (`rows: "auto"`), tightened the `getCardSize()` fallback, and dropped the ineffective `flex: 1` from `.not-found`. Fixes [#23](https://github.com/mawinkler/astroweather-card/issues/23).
+
 ## [0.80.0](https://github.com/mawinkler/astroweather-card/compare/v0.74.2...v0.80.0) (2026-05-29)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is jan-tdy's fork!
+# Work in progress!
 # Lovelace AstroWeather Card
 
 ![GitHub release](https://img.shields.io/badge/release-v0.80.0-blue)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This Integration is part of the default HACS store, so go to the HACS page and s
 
 ### Manual Installation
 
-To add the AstroWeather card to your installation, download the `astroweather-card.js` from the [release](https://raw.githubusercontent.com/jan-tdy/AstroCard-ADV/main/dist/astroweather-card.js)-page and copy it to `/config/www/custom-lovelace/astroweather-card/`.
+To add the AstroWeather card to your installation, download the `astroweather-card.js` from the [release](https://raw.githubusercontent.com/mawinkler/astroweather-card/main/dist/astroweather-card.js)-page and copy it to `/config/www/custom-lovelace/astroweather-card/`.
 
 Add the card to your dashboard by choosing `[Edit Dashboard]` and then `[Manage Resources]`.
 
@@ -155,9 +155,9 @@ To do development work on this card (either for your personal use, or to contrib
 1. Create a fork of this repository on GitHub
 2. Download and setup the repository on your local machine, by running:
 ```
-git clone https://github.com/jan-tdy/AstroCard-ADV
+git clone https://github.com/mawinkler/astroweather-card
 cd astroweather-card
-git remote add upstream https://github.com/jan-tdy/AstroCard-ADV
+git remote add upstream https://github.com/mawinkler/astroweather-card
 ```
 3. Once the repository is setup, install the npm dependencies with `npm install`
 4. Make local edits as needed to the grocy chores card. 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This Integration is part of the default HACS store, so go to the HACS page and s
 
 ### Manual Installation
 
-To add the AstroWeather card to your installation, download the `astroweather-card.js` from the [release](https://raw.githubusercontent.com/mawinkler/astroweather-card/main/dist/astroweather-card.js)-page and copy it to `/config/www/custom-lovelace/astroweather-card/`.
+To add the AstroWeather card to your installation, download the `astroweather-card.js` from the [release](https://raw.githubusercontent.com/jan-tdy/AstroCard-ADV/main/dist/astroweather-card.js)-page and copy it to `/config/www/custom-lovelace/astroweather-card/`.
 
 Add the card to your dashboard by choosing `[Edit Dashboard]` and then `[Manage Resources]`.
 
@@ -155,9 +155,9 @@ To do development work on this card (either for your personal use, or to contrib
 1. Create a fork of this repository on GitHub
 2. Download and setup the repository on your local machine, by running:
 ```
-git clone https://github.com/mawinkler/astroweather-card
+git clone https://github.com/jan-tdy/AstroCard-ADV
 cd astroweather-card
-git remote add upstream https://github.com/mawinkler/astroweather-card
+git remote add upstream https://github.com/jan-tdy/AstroCard-ADV
 ```
 3. Once the repository is setup, install the npm dependencies with `npm install`
 4. Make local edits as needed to the grocy chores card. 

--- a/src/astroweather-card.ts
+++ b/src/astroweather-card.ts
@@ -196,13 +196,25 @@ export class AstroWeatherCard extends LitElement {
 
   public getCardSize(): number {
     const card = this.shadowRoot?.querySelector("ha-card");
-    if (!card) return 4; // fallback
+    if (!card) return 1; // fallback
 
     // Pixel height of the card
     const height = card.getBoundingClientRect().height;
+    if (!height) return 1;
 
     // Convert pixels → "rows" (approx. 50px per row in Lovelace grid)
     return Math.ceil(height / 50);
+  }
+
+  // Let the "sections" dashboard view size the card to its actual content
+  // instead of stretching it to a fixed grid row height (which made the
+  // not-found/error states look badly stretched, see GH issue #23).
+  public getGridOptions() {
+    return {
+      columns: 12,
+      rows: "auto",
+      min_rows: 1,
+    };
   }
 
   subscribeForecastEvents() {
@@ -325,17 +337,7 @@ export class AstroWeatherCard extends LitElement {
   }
 
   static get styles() {
-    return [
-      style,
-      css`
-        .not-found {
-          flex: 1;
-          background-color: yellow;
-          color: black;
-          padding: 8px;
-        }
-      `,
-    ];
+    return [style];
   }
 
   // Render card

--- a/src/astroweather-card.ts
+++ b/src/astroweather-card.ts
@@ -196,14 +196,29 @@ export class AstroWeatherCard extends LitElement {
 
   public getCardSize(): number {
     const card = this.shadowRoot?.querySelector("ha-card");
-    if (!card) return 1; // fallback
+    if (card) {
+      // Pixel height of the card, converted to "rows" (~50px/row).
+      const height = card.getBoundingClientRect().height;
+      if (height) return Math.ceil(height / 50);
+    }
 
-    // Pixel height of the card
-    const height = card.getBoundingClientRect().height;
-    if (!height) return 1;
+    // ha-card hasn't rendered yet (e.g. the masonry view calls this before
+    // appending the card to a column). Only the not-found/error states are
+    // actually compact; a normal card should still get a size estimate
+    // roughly matching its enabled sections instead of always reporting 1.
+    const stateObj = this._hass?.states[this._config?.entity];
+    const isValidEntity = !!stateObj?.attributes?.attribution?.startsWith(
+      "Powered by Met.no"
+    );
+    if (!isValidEntity) return 1;
 
-    // Convert pixels → "rows" (approx. 50px per row in Lovelace grid)
-    return Math.ceil(height / 50);
+    let rows = 1;
+    if (this._config.current !== false) rows += 1;
+    if (this._config.details !== false) rows += 1;
+    if (this._config.deepskydetails !== false) rows += 1;
+    if (this._config.forecast !== false) rows += 1;
+    if (this._config.graph !== false) rows += 3;
+    return rows;
   }
 
   // Let the "sections" dashboard view size the card to its actual content

--- a/src/style.ts
+++ b/src/style.ts
@@ -187,7 +187,6 @@ const style = css`
     }
 
     .not-found {
-        flex: 1;
         background-color: yellow;
         color: black;
         padding: 8px;


### PR DESCRIPTION
Summary

    The card (most visibly its "entity not available" / "not an AstroWeather entity" error states) rendered badly stretched in Home Assistant's Sections dashboard view.
    Root cause: getCardSize() fell back to a fixed 4 rows whenever it was queried before the card had rendered (e.g. ha-card not yet in the shadow DOM), and .not-found used flex: 1 inside a ha-card that isn't a flex container — neither reflected the card's real, much smaller content height.
    Added getGridOptions() (rows: "auto") so the Sections view sizes the card to its actual content instead of a fixed grid-row height.
    Tightened the getCardSize() fallback (1 instead of 4, and guard against a 0-height measurement).
    Dropped the ineffective flex: 1 from .not-found and removed the duplicate .not-found style block.

Fixes https://github.com/mawinkler/astroweather-card/issues/23.
Test plan

    npm run build compiles cleanly (rollup)
    Manually verify in a Home Assistant Sections dashboard that the card (normal state and the "entity not available" error state) sizes to its content instead of stretching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPwWQTmp1HjDdv7PoKN4Sd

Generated by [Claude Code](https://claude.ai/code/session_01KPwWQTmp1HjDdv7PoKN4Sd)
Summary by CodeRabbit

    Bug Fixes
        Corrected dashboard layout behavior for Sections cards to prevent excessive stretching.
        Improved automatic grid sizing with a one-row minimum.
        Adjusted default card sizing when dimensions cannot be determined.
        Refined the “not found” card layout for more consistent sizing.